### PR TITLE
Make lab6B solvable by getting rid of null byte

### DIFF
--- a/src/lab06/lab6B.c
+++ b/src/lab06/lab6B.c
@@ -165,6 +165,7 @@ int main(int argc, char* argv[])
     /* hash the password we'll be comparing against */
     hash_pass(secretpw, "lab6A");
     printf("----------- FALK OS LOGIN PROMPT -----------\n");
+    fflush(stdout);
 
     /* authorization loop */
     if(login_prompt(pwsize, secretpw))


### PR DESCRIPTION
The VM binary is not solvable, because the stack contains null byte. I tried to recompile the binary but unfortunately nothing changed, the part of stack after breaking on line

`=> 0xb77e5e59 <login_prompt+291>:	call   0xb77e5b2d <hash_pass>`:
```
0216| 0xbf973af8 --> 0xffffffff
0220| 0xbf973afc --> 0xfffffffe
0224| 0xbf973b00 --> 0x0
0228| 0xbf973b04 --> 0xb7788f78 --> 0x2e80
0232| 0xbf973b08 --> 0xbf973b38 --> 0x0
0236| 0xbf973b0c --> 0xb7786f6e (<main+173>:    test   eax,eax)
```
After fix I was able to complete the level:
```
0216| 0xbff07e28 --> 0xffffffff 
0220| 0xbff07e2c --> 0xfffffffe 
0224| 0xbff07e30 --> 0xb77e7f78 --> 0x2e80 
0228| 0xbff07e34 --> 0xb77e7f78 --> 0x2e80 
0232| 0xbff07e38 --> 0xbff07e68 --> 0x0 
0236| 0xbff07e3c --> 0xb77e5f7e (<main+189>:	test   eax,eax)
```