### PR TITLE
Incorrect compile flags in source for lab8A and lab9A

### DIFF
--- a/src/lab08/lab8A.c
+++ b/src/lab08/lab8A.c
@@ -4,7 +4,7 @@
 #include "utils.h"
 #define STDIN 0
 
-//gcc -fstack-protector-all -mpreferred-stack-boundary=2 -o lab8A lab8A.c
+//gcc -static -fstack-protector-all -mpreferred-stack-boundary=2 -o lab8A lab8A.c
 int *global_addr;
 int *global_addr_check;
 


### PR DESCRIPTION
lab8A is not a dynamic library however the compilation comment in the source does not reflect this