### PR TITLE
incorrect variable use in pwn_read

### DIFF
--- a/src/lab10/lab10A.c
+++ b/src/lab10/lab10A.c
@@ -133,7 +133,7 @@ void default_callback(struct sk_buff  * skb) {
 
 static ssize_t pwn_read(struct file* file, char * buf, size_t count, loff_t *ppos)
 {
-    return len;
+    return count;
 }
 
 int add_cfilter(struct callback_filter * filt) {


### PR DESCRIPTION
pwn_read() returns 'len' which causes a compiler error as it is not defined. I think what was meant here was to return 'count' instead.

Signed-off-by: marky <mark@noffle.net>